### PR TITLE
remove unnecessary output redirection from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "template-for-proposals",
   "description": "A repository template for ECMAScript proposals.",
   "scripts": {
-    "build": "ecmarkup spec.emu > index.html"
+    "build": "ecmarkup spec.emu index.html"
   },
   "homepage": "https://github.com/tc39/template-for-proposals#readme",
   "repository": {


### PR DESCRIPTION
The output redirection causes errors and warnings to show up at the top of index.html.

```
./node_modules/.bin/ecmarkup --help

Usage: ecmarkup <infile> [outfile] [options]

infile      Input ecmarkup file
outfile     Output html or biblio file
```

With this change

```sh
npm run build options
```

will also thread the options through to ecmarkup.