### PR TITLE
Replace "member" by "delegate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A repository template for ECMAScript proposals.
 Please ensure the following:
   1. You have read the [process document](https://tc39.github.io/process-document/)
   1. You have reviewed the [existing proposals](https://github.com/tc39/proposals/)
-  1. You are aware that your proposal requires being a member of TC39, or locating a TC39 member to "champion" your proposal
+  1. You are aware that your proposal requires being a member of TC39, or locating a TC39 delegate to "champion" your proposal
 
 ## Create your proposal repo
 


### PR DESCRIPTION
Ecma / TC39 members are organizations so it'd be better to use word "delegate" instead