### PR TITLE
Bump ecmarkup and pass more flags to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "name": "template-for-proposals",
   "description": "A repository template for ECMAScript proposals.",
   "scripts": {
-    "start": "npm run build -- --watch",
-    "build": "ecmarkup spec.emu index.html"
+    "start": "npm run build-loose -- --watch",
+    "build": "npm run build-loose -- --strict",
+    "build-loose": "ecmarkup --verbose spec.emu index.html"
   },
   "homepage": "https://github.com/tc39/template-for-proposals#readme",
   "repository": {
@@ -13,6 +14,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "ecmarkup": "^3.25.3"
+    "ecmarkup": "^4.0.0"
   }
 }


### PR DESCRIPTION
`--verbose` gives much more useful error output (and also prints progress messages). `--strict` makes the build fail if there are any errors.