### PR TITLE
fix(spec): add missing subresource integrity checks for css from cdns

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset="utf8">
 <link rel="stylesheet" href="./spec.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css" integrity="sha512-iDO4iL6PUvPt54yn8f29JSkoMrScHRIMArsHJtOTGg2yTHWT7dfvziWeXIneGy+wGwbrhGMg1a1ntA+sNA+atg==" crossorigin="anonymous">
 <script src="./spec.js"></script>
 <pre class="metadata">
 title: Proposal Title Goes Here


### PR DESCRIPTION
This fixes a bug that causes ci failure for folks with codeql actions enabled for their proposal template repos.

I thought handling all cases where this comes up locally would suffice, but then that fixup commit comes and messes it all up again https://github.com/DerekNonGeneric/proposal-assertion-error/pull/14, so maybe fixing it here would be preferable.

/cc @ljharb @bakkot